### PR TITLE
去除查询产品ID自带发起支付

### DIFF
--- a/IAPManager/IAPManager/IAPManager.m
+++ b/IAPManager/IAPManager/IAPManager.m
@@ -208,12 +208,12 @@
         DLog(@"描述信息----->%@\n产品标题----->%@\n产品描述信息----->%@\n价格(货币)----->%@(%@)\n\nproductIdentifier----->%@\n",product.description, product.localizedTitle, product.localizedDescription, product.price, product.priceLocale.currencyCode, product.productIdentifier)
     }
     
-    if (self.paymentVerify.purchaseContent.productId) {
-        self.paymentVerify.purchaseContent.product = products.firstObject;
-        //发送购买请求
-        SKPayment *payment = [SKPayment paymentWithProduct:products.firstObject];
-        [[SKPaymentQueue defaultQueue] addPayment:payment];
-    }
+//     if (self.paymentVerify.purchaseContent.productId) {
+//         self.paymentVerify.purchaseContent.product = products.firstObject;
+//         //发送购买请求
+//         SKPayment *payment = [SKPayment paymentWithProduct:products.firstObject];
+//         [[SKPaymentQueue defaultQueue] addPayment:payment];
+//     }
 }
 
 //MARK: 反馈请求失败


### PR DESCRIPTION
例子中先发起查询后购买的情况，会导致addPayment实际执行两次。
如果需要fetchProductInfoWithProductIdentifiers后对SKProduct进行验证（如货币类型等），则会无效，因为会被productsRequest提前调起支付。